### PR TITLE
Beat Detection Tweak

### DIFF
--- a/code/vis_milk2/plugin.h
+++ b/code/vis_milk2/plugin.h
@@ -60,6 +60,7 @@ typedef struct
 	float	long_avg[3];	// bass, mids, treble (absolute)
     float   fWave[2][576];
     float   fSpecLeft[MY_FFT_SAMPLES];
+    float   fSpecRight[MY_FFT_SAMPLES];
 } td_mysounddata;
 
 typedef struct


### PR DESCRIPTION
I fixed the beat detection from hearing the treble (high frequencies) to bass, mid and treb variables.
Now I made the perfect and accurate beat detection for any music you want.

Check [this video demo](https://twitter.com/OctobellaMilkD/status/1625587045174476800?s=20) how I fixed the beat detection.

Plus, this can be reacted on both channels (mono), like projectM.